### PR TITLE
Fulfill "Advanced Mode"

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ exports = {
 
 A sample config file is here: [`sample_config.py`](https://github.com/outloudvi/mw2fcitx/blob/master/mw2fcitx/sample_config.py)
 
+## Advanced mode
+
+As `mw2fcitx` provides the feature to append and override MediaWiki API parameters, it is possible to use it to collect other types of lists in addition to [`allpages`](https://www.mediawiki.org/wiki/Special:MyLanguage/API:Allpages). Please note that if `list`, `action` or `format` is overriden in `api_params`, `mw2fcitx` will not automatically append default parameters (including `aplimit`) while sending MediaWiki API requests. Please determine the parameters needed by yourself. [A configuration in tests](tests/cli/conf_list_categorymembers.py) may be helpful for your reference.
+
 ## Breaking changes across versions
 
 Read [BREAKING_CHANGES.md](./BREAKING_CHANGES.md) for details.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ A sample config file is here: [`sample_config.py`](https://github.com/outloudvi/
 
 ## Advanced mode
 
-As `mw2fcitx` provides the feature to append and override MediaWiki API parameters, it is possible to use it to collect other types of lists in addition to [`allpages`](https://www.mediawiki.org/wiki/Special:MyLanguage/API:Allpages). Please note that if `list`, `action` or `format` is overriden in `api_params`, `mw2fcitx` will not automatically append default parameters (including `aplimit`) while sending MediaWiki API requests. Please determine the parameters needed by yourself. [A configuration in tests](tests/cli/conf_list_categorymembers.py) may be helpful for your reference.
+As `mw2fcitx` provides the feature to append and override MediaWiki API parameters, it is possible to use it to collect other types of lists in addition to [`allpages`](https://www.mediawiki.org/wiki/Special:MyLanguage/API:Allpages). Please note that if `list`, `action` or `format` is overriden in `api_params`, `mw2fcitx` will not automatically append any default parameter (except for `format`) while sending MediaWiki API requests. Please determine the parameters needed by yourself. [A configuration in tests](tests/cli/conf_list_categorymembers.py) may be helpful for your reference.
 
 ## Breaking changes across versions
 

--- a/mw2fcitx/const.py
+++ b/mw2fcitx/const.py
@@ -3,3 +3,4 @@ LIBIME_REPOLOGY_URL = "https://repology.org/project/libime"
 PARTIAL_DEPRECATED_APCONTINUE = "apcontinue"
 PARTIAL_CONTINUE_DICT = "continue_dict"
 PARTIAL_TITLES = "titles"
+ADVANCED_MODE_TRIGGER_PARAMETER_NAMES = ["action", "list", "format"]

--- a/mw2fcitx/fetch.py
+++ b/mw2fcitx/fetch.py
@@ -80,8 +80,9 @@ def populate_api_params(custom_api_params: dict, deprecated_aplimit: Union[None,
             console.warning(
                 "Warn: `source.kwargs.aplimit` is deprecated - "
                 "please use `source.kwargs.api_param.aplimit` instead.")
-        aplimit = int(
-            deprecated_aplimit) if deprecated_aplimit != "max" and deprecated_aplimit is not None else "max"
+        aplimit = int(deprecated_aplimit) \
+            if deprecated_aplimit != "max" and deprecated_aplimit is not None \
+            else "max"
         if "aplimit" not in custom_api_params:
             custom_api_params["aplimit"] = aplimit
 

--- a/tests/cli/conf_err_invalid_api_params.py
+++ b/tests/cli/conf_err_invalid_api_params.py
@@ -6,12 +6,10 @@ exports = {
         "kwargs": {
             "title_limit": 10,
             "api_params": {
-                "action": "query",
-                "list": "categorymembers",
-                "cmtitle": "Category:天津市历史风貌建筑",
-                "cmlimit": 5
+                "action": "paraminfo",
+                "modules": "query+allpages"
             },
-            "output": "test_list_categorymembers.titles.txt"
+            "output": "test_err_invalid_api_params.titles.txt"
         }
     },
     "tweaks": [],

--- a/tests/cli/conf_list_categorymembers.py
+++ b/tests/cli/conf_list_categorymembers.py
@@ -7,7 +7,8 @@ exports = {
             "title_limit": 10,
             "api_params": {
                 "list": "categorymembers",
-                "cmtitle": "Category:天津市历史风貌建筑"
+                "cmtitle": "Category:天津市历史风貌建筑",
+                "cmlimit": 5
             },
             "output": "test_list_categorymembers.titles.txt"
         }

--- a/tests/cli/test_conf.py
+++ b/tests/cli/test_conf.py
@@ -61,3 +61,8 @@ def test_list_categorymembers():
     inner_main(['-c', 'tests/cli/conf_list_categorymembers'])
     with open("test_list_categorymembers.titles.txt", "r", encoding="utf-8") as f:
         assert len(f.read().split("\n")) == 10
+
+
+def test_err_no_path():
+    with pytest.raises(SystemExit):
+        inner_main(['-c', 'tests/cli/conf_err_invalid_api_params'])


### PR DESCRIPTION
Do NOT populate any default parameters (e.g. `aplimit`) for MediaWiki API when detecting `list`, `action` or `format` is in `api_params`.

Useful for users who want to use lists other than `allpages` (e.g. `categorymembers`).

ref: #42